### PR TITLE
Update for Swift 4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+
+## Other
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+*.xcscmblueprint
+.DS_Store
+
+Slack Files/OAuth2/Credentials.h
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the 
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://github.com/fastlane/fastlane/blob/master/docs/Gitignore.md
+
+fastlane/report.xml
+fastlane/screenshots

--- a/BinaryCodableExtensions.swift
+++ b/BinaryCodableExtensions.swift
@@ -3,29 +3,21 @@
 import Foundation
 
 
-extension Array: BinaryCodable {
+extension Array: BinaryCodable where Element: Codable {
     public func binaryEncode(to encoder: BinaryEncoder) throws {
-        guard Element.self is Encodable.Type else {
-            throw BinaryEncoder.Error.typeNotConformingToEncodable(Element.self)
-        }
-        
         try encoder.encode(self.count)
         for element in self {
-            try (element as! Encodable).encode(to: encoder)
+            try element.encode(to: encoder)
         }
     }
     
     public init(fromBinary decoder: BinaryDecoder) throws {
-        guard let binaryElement = Element.self as? Decodable.Type else {
-            throw BinaryDecoder.Error.typeNotConformingToDecodable(Element.self)
-        }
-        
         let count = try decoder.decode(Int.self)
         self.init()
         self.reserveCapacity(count)
         for _ in 0 ..< count {
-            let decoded = try binaryElement.init(from: decoder)
-            self.append(decoded as! Element)
+            let decoded = try Element.self.init(from: decoder)
+            self.append(decoded)
         }
     }
 }

--- a/BinaryCoder.xcodeproj/project.pbxproj
+++ b/BinaryCoder.xcodeproj/project.pbxproj
@@ -146,9 +146,11 @@
 					C21B17891F21827F00286183 = {
 						CreatedOnToolsVersion = 9.0;
 						LastSwiftMigration = "";
+						ProvisioningStyle = Automatic;
 					};
 					C21B17961F2182DD00286183 = {
 						CreatedOnToolsVersion = 9.0;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -318,12 +320,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = 44N4WJ59X4;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 9V7A84BPER;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
 			};
@@ -333,12 +338,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = 44N4WJ59X4;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 9V7A84BPER;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				EXECUTABLE_PREFIX = lib;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
@@ -346,12 +354,15 @@
 		C21B17A01F2182DD00286183 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 44N4WJ59X4;
+				DEVELOPMENT_TEAM = 9V7A84BPER;
 				INFOPLIST_FILE = BinaryEncoderTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mikeash.BinaryEncoderTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
@@ -361,12 +372,15 @@
 		C21B17A11F2182DD00286183 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 44N4WJ59X4;
+				DEVELOPMENT_TEAM = 9V7A84BPER;
 				INFOPLIST_FILE = BinaryEncoderTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mikeash.BinaryEncoderTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;
 			};


### PR DESCRIPTION
- Added a .gitignore file to prevent pulling in tons of new Xcode project files
- Updated Array encoding extension for Swift 4.2

Builds without warnings.
All tests pass.